### PR TITLE
Make erlang_additional_packages installation compatible with ansible 2.x

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -16,5 +16,16 @@
     force: "{{ erlang_packages_force }}"
   with_items: erlang_additional_packages
   when: erlang_additional_packages is defined and
-        erlang_additional_packages != []
+        erlang_additional_packages != [] and
+        ansible_version.major < 2
 
+  apt:
+    pkg: "{{ item }}"
+    update_cache: yes
+    cache_valid_time: 3600
+    state: "{{ erlang_packages_state }}"
+    force: "{{ erlang_packages_force }}"
+  with_items: "{{ erlang_additional_packages }}"
+  when: erlang_additional_packages is defined and
+        erlang_additional_packages != [] and
+        ansible_version.major >= 2


### PR DESCRIPTION
This fix addresses the

```
failed: [hostname] (item=[u'erlang_additional_packages']) => {"failed": true, "item": ["erlang_additional_packages"], "msg": "No package matching 'erlang_additional_packages' is available"}
```

issue with solution provided in https://github.com/ansible/ansible/issues/14032